### PR TITLE
Deploy mkdocs documentation page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
 name: Documentation
 
 on:
+  # Uncomment the 'pull_request' line below to manually re-build Jupyter Book
+  pull_request:
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,6 @@
 name: Documentation
 
 on:
-  # Uncomment the 'pull_request' line below to manually re-build Jupyter Book
-  pull_request:
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: 3.x
+          python-version: 3.13
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04-arm
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read # required to checkout repository
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.x
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build HTML docs
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vbos-backend
 
-[![Docker](https://github.com/developmentseed/vbos-backend/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/developmentseed/vbos-backend/actions/workflows/docker-publish.yml)
+[![Docker](https://github.com/Vanuatu-National-Statistics-Office/vbos-backend/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/Vanuatu-National-Statistics-Office/vbos-backend/actions/workflows/docker-publish.yml)
 [![Built with](https://img.shields.io/badge/Built_with-Cookiecutter_Django_Rest-F7B633.svg)](https://github.com/agconti/cookiecutter-django-rest)
 
 VBOS Django application and data services. Check out the project's [documentation](http://developmentseed.github.io/vbos-backend/).

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,6 +1,7 @@
 # Data Imports
 
-To add data into the system, the first step needed is to create a superuser account. Check the [index.md](/docs/index.md#initialize-the-project) for instructions on how to do it.
+To add data into the system, the first step needed is to create a superuser account.
+Check the [index.md](index.md#initialize-the-project) for instructions on how to do it.
 
 With the superuser account, you can login on the Administration Interface. The URL will be: `{backend-url}/admin`.
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -6,7 +6,7 @@ With the superuser account, you can login on the Administration Interface. The U
 
 Once logged in, you will see a screen like this:
 
-<img width="2764" height="1492" alt="image" src="https://github.com/user-attachments/assets/109f4712-9577-4bef-8b4c-153620f3a2b1" />
+![image](https://github.com/user-attachments/assets/109f4712-9577-4bef-8b4c-153620f3a2b1)
 
 ## Adding data
 
@@ -19,20 +19,20 @@ On the Administrative Interface, click on Clusters, then on `Add Cluster` button
 
 You will see a form like this. Add a name and click on Save.
 
-<img width="50%" alt="image" src="https://github.com/user-attachments/assets/c7f62081-3d2f-4fa7-8b24-0a8c032a018c" />
+![image](https://github.com/user-attachments/assets/c7f62081-3d2f-4fa7-8b24-0a8c032a018c)
 
 If you need to modify or delete a Cluster, you can do it by accessing the Cluster list page in the administrative interface.
 
 Clicking on the id of the cluster, you will have access to the form to modify it. If you need to delete clusters, select it and then click on the action dropdown and select `Delete selected clusters`. Finally, click on the `Go` button.
 
-<img width="50%" alt="image" src="https://github.com/user-attachments/assets/01f27226-566e-44c4-b279-6c818b53ff2e" />
+![image](https://github.com/user-attachments/assets/01f27226-566e-44c4-b279-6c818b53ff2e)
 
 
 ### Creating datasets
 
 The exact same pattern applies when creating Raster, Vector or Tabular datasets. Here you can see the Raster Dataset creation form:
 
-<img width="100%" alt="image" src="https://github.com/user-attachments/assets/01a838fb-8ab1-4cef-bab7-e1ebf624fa8e" />
+![image](https://github.com/user-attachments/assets/01a838fb-8ab1-4cef-bab7-e1ebf624fa8e)
 
 The forms to create Vector and Tabular datasets are very similar to the Raster one.
 
@@ -44,11 +44,11 @@ The last and most important step of the data import is to upload the files conta
 
 Click on the `Tabular Items` link in the Administrative Interface homepage. Then, click on `Import File` in the right-top corner of the page.
 
-<img width="2210" height="1006" alt="image" src="https://github.com/user-attachments/assets/65dc540a-9bdf-4690-ab65-6d005aa22d96" />
+![image](https://github.com/user-attachments/assets/65dc540a-9bdf-4690-ab65-6d005aa22d96)
 
 Once clicked, you will see a form like this, where you can upload a CSV file and select the dataset to which the data belongs to:
 
-<img width="80%" alt="image" src="https://github.com/user-attachments/assets/2702ae31-a4ec-4cfa-b782-7045876314c4" />
+![image](https://github.com/user-attachments/assets/2702ae31-a4ec-4cfa-b782-7045876314c4)
 
 The CSV file needs to be separated by commas and should have the following columns:
 
@@ -65,11 +65,11 @@ The name of the columns can be in lower, UPPER, or Camel Case. You can upload a 
 
 Click on the `Vector Items` link in the Administrative Interface homepage. Then, click on `Import File` in the right-top corner of the page.
 
-<img width="2204" height="928" alt="image" src="https://github.com/user-attachments/assets/b6cd7cab-c9bd-4956-87f2-08268d848602" />
+![image](https://github.com/user-attachments/assets/b6cd7cab-c9bd-4956-87f2-08268d848602)
 
 Once clicked, you will see a form like this, where you can upload a GeoJSON file and select the dataset to which the data belongs to:
 
-<img width="50%" alt="image" src="https://github.com/user-attachments/assets/e65938e5-43b0-405d-9fdd-446b182a4e88" />
+![image](https://github.com/user-attachments/assets/e65938e5-43b0-405d-9fdd-446b182a4e88)
 
 If you have never worked with GeoJSON files, you can convert any geospatial data format to GeoJSON using QGIS or ArcGis. The items in the GeoJSON file should have the following columsn:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,10 @@
 # vbos-backend
 
-[![Build Status](https://travis-ci.org/developmentseed/vbos-backend.svg?branch=master)](https://travis-ci.org/developmentseed/vbos-backend)
+[![Django CI](https://github.com/Vanuatu-National-Statistics-Office/vbos-backend/actions/workflows/test.yml/badge.svg)](https://github.com/Vanuatu-National-Statistics-Office/vbos-backend/actions/workflows/test.yml)
 [![Built with](https://img.shields.io/badge/Built_with-Cookiecutter_Django_Rest-F7B633.svg)](https://github.com/agconti/cookiecutter-django-rest)
 
-VBOS Django application and data services. Check out the project's [documentation](http://developmentseed.github.io/vbos-backend/).
+VBOS Django application and data services.
+Check out the project's [source code](https://github.com/Vanuatu-National-Statistics-Office/vbos-backend/).
 
 # Prerequisites
 

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,8 @@ copyright: Copyright &copy; 2020, <a href="https://github.com/developmentseed">d
 dev_addr: 0.0.0.0:8001
 
 nav:
-  - Home: 'index.md'
+  - Home: "index.md"
+  - "data.md"
   - API:
-    - Authentication: 'api/authentication.md'
-    - Users: 'api/users.md'
+      - Authentication: "api/authentication.md"
+      - Users: "api/users.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,9 @@ site_dir: site
 copyright: Copyright &copy; 2026, <a href="https://vbos.gov.vu/">Vanuatu Bureau of Statistics</a>.
 dev_addr: 0.0.0.0:8001
 
+theme:
+  name: mkdocs
+  navigation_depth: 3
 nav:
   - Home: "index.md"
   - "data.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,9 @@
-site_name: vbos
+site_name: vbos-backend
 site_description: VBOS Django application and data services
-repo_url: https://github.com/developmentseed/vbos-backend
+repo_url: https://github.com/Vanuatu-National-Statistics-Office/vbos-backend
+docs_dir: docs
 site_dir: site
-copyright: Copyright &copy; 2020, <a href="https://github.com/developmentseed">developmentseed</a>.
+copyright: Copyright &copy; 2026, <a href="https://vbos.gov.vu/">Vanuatu Bureau of Statistics</a>.
 dev_addr: 0.0.0.0:8001
 
 nav:


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Add static site for documentation under `docs/` folder
- **Preview** at https://vanuatu-national-statistics-office.github.io/vbos-backend/

<img width="1216" height="909" alt="image" src="https://github.com/user-attachments/assets/097cc26b-4f2c-4507-918e-e58c428e5884" />

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- [x] Setup GitHub Actions continuous integration workflow to build docs
- [x] Update some links
- [ ] etc

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run the following locally:
```python
cd vbos-backend
python3 -m venv .venv
source .venv/bin/activate
pip install -r requirements.txt
mkdocs build
```

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
Ref: https://www.mkdocs.org/user-guide/deploying-your-docs/#github-pages

Closes #36